### PR TITLE
compatibility with .NET 3.5

### DIFF
--- a/NetSerializer/Primitives.cs
+++ b/NetSerializer/Primitives.cs
@@ -18,7 +18,7 @@ namespace NetSerializer
 		internal static MethodInfo GetWritePrimitive(Type type)
 		{
 			if (type.IsEnum)
-				type = type.GetEnumUnderlyingType();
+				type = Enum.GetUnderlyingType(type);
 
 			MethodInfo writer = typeof(Primitives).GetMethod("WritePrimitive", BindingFlags.Static | BindingFlags.Public | BindingFlags.ExactBinding, null,
 				new Type[] { typeof(Stream), type }, null);
@@ -61,7 +61,7 @@ namespace NetSerializer
 		internal static MethodInfo GetReadPrimitive(Type type)
 		{
 			if (type.IsEnum)
-				type = type.GetEnumUnderlyingType();
+				type = Enum.GetUnderlyingType(type);
 
 			var reader = typeof(Primitives).GetMethod("ReadPrimitive", BindingFlags.Static | BindingFlags.Public | BindingFlags.ExactBinding, null,
 				new Type[] { typeof(Stream), type.MakeByRefType() }, null);

--- a/NetSerializer/Serializer.cs
+++ b/NetSerializer/Serializer.cs
@@ -185,7 +185,9 @@ namespace NetSerializer
 			il.Emit(OpCodes.Switch, jumpTable);
 
 			D(il, "eihx");
-			il.ThrowException(typeof(Exception));
+			ConstructorInfo exceptionCtor = typeof(Exception).GetConstructor(BindingFlags.Public | BindingFlags.Instance, null, new Type[0], null);
+			il.Emit(OpCodes.Newobj, exceptionCtor);
+			il.Emit(OpCodes.Throw);
 
 			/* null case */
 			il.MarkLabel(jumpTable[0]);


### PR DESCRIPTION
- move appart the compatibility patch
- indentation with tab should be ok
- ThrowException is rewritten because buggy under 3.5 with DynamicMethod
