### PR TITLE
.NET Core support

### DIFF
--- a/Doc.md
+++ b/Doc.md
@@ -27,7 +27,7 @@ NetSerializer supports serializing the following types:
 - With client-server, both client and server must set up the NetSerializer in
   the same way, providing the same types (and type IDs).
 
-## Usage
+## Usage (.NET 4.x)
 
 The types to be serialized need to be marked with the standard
 `[Serializable]`. You can also use `[NonSerialized]` for fields you don't
@@ -51,6 +51,13 @@ server), as the type IDs are assigned according to the list.
 
 There is also a possibility to add types later via [type maps](#type-maps),
 which is somewhat complex and only recommended if absolutely needed.
+
+## Usage (.NET Core)
+
+The `SerializableAttribute` is no more. Thus, under .NET Core, `NetSerializer`
+treats all classes as serializable by default. The setting 
+`Settings.SupportISerializable` is available in .NET 4.x to adjust the behavior
+to be the same in .NET Core.
 
 ## Example
 

--- a/NETCore.md
+++ b/NETCore.md
@@ -26,6 +26,5 @@ the fast overloads.
 
 ## Debugging Assembly and `AppDomain`
 
-The `AppDomain` are no more in .NET Core (for now), and the debugging
-was introducing quite a layer of complexity. It has been opted to
-remove the feature entirely from the library.
+The `AppDomain` are no more in .NET Core (for now), so the compile flag
+`GENERATE_DEBUGGING_ASSEMBLY` does not work in .NET Core.

--- a/NETCore.md
+++ b/NETCore.md
@@ -1,0 +1,31 @@
+# .NET Core port notes of NetSerialization
+By Joannes Vermorel, August 2016
+
+## The `DNXCORE50` compile flag
+
+.NET Core is not fully backward compatible with .NET 4.x. Thus,
+the compile flage `DNXCORE50` has been introduce in the solution
+to adjust the code to make it compatible with .NET Core.
+
+## `ISerializable` is no more in .NET Core
+
+In .NET Core, the `ISerializable` interface is no more. Actually,
+the need to flag classes with `ISerializable` was questionnable
+even in .NET 4.x. Thus, `ISerializable` behavior can now be avoided
+through `Settings.SupportISerializable` in .NET 4.x, and while it is
+completely ignored under .NET Core.
+
+## `Encoder.GetByteCount()` and `Encoder.Convert()`
+
+The pointer-based overload of `Encoder.GetByteCount()` and `Encoder.Convert()`
+have not been ported yet to .NET Core, but those overloads are already planned
+for the version 1.2. For the time being, the .NET Core behavior of NetSerializer
+relies on slow non-pointer overload. Once the pointer overloads become available
+in .NET Core, this change should be reverted. The .NET 4.x version is still using
+the fast overloads.
+
+## Debugging Assembly and `AppDomain`
+
+The `AppDomain` are no more in .NET Core (for now), and the debugging
+was introducing quite a layer of complexity. It has been opted to
+remove the feature entirely from the library.

--- a/NetSerializer/Helpers.cs
+++ b/NetSerializer/Helpers.cs
@@ -45,9 +45,10 @@ namespace NetSerializer
 				new Type[] { typeof(Serializer), typeof(Stream), type },
 				typeof(Serializer), true);
 
-			dm.DefineParameter(1, ParameterAttributes.None, "serializer");
-			dm.DefineParameter(2, ParameterAttributes.None, "stream");
-			dm.DefineParameter(3, ParameterAttributes.None, "value");
+            // .NET Core does not support 'DefineParameter'
+			//dm.DefineParameter(1, ParameterAttributes.None, "serializer");
+			//dm.DefineParameter(2, ParameterAttributes.None, "stream");
+			//dm.DefineParameter(3, ParameterAttributes.None, "value");
 
 			return dm;
 		}
@@ -57,9 +58,11 @@ namespace NetSerializer
 			var dm = new DynamicMethod("Deserialize", null,
 				new Type[] { typeof(Serializer), typeof(Stream), type.MakeByRefType() },
 				typeof(Serializer), true);
-			dm.DefineParameter(1, ParameterAttributes.None, "serializer");
-			dm.DefineParameter(2, ParameterAttributes.None, "stream");
-			dm.DefineParameter(3, ParameterAttributes.Out, "value");
+
+            // .NET Core does not support 'DefineParameter'
+            //dm.DefineParameter(1, ParameterAttributes.None, "serializer");
+			//dm.DefineParameter(2, ParameterAttributes.None, "stream");
+			//dm.DefineParameter(3, ParameterAttributes.Out, "value");
 
 			return dm;
 		}

--- a/NetSerializer/Helpers.cs
+++ b/NetSerializer/Helpers.cs
@@ -67,10 +67,32 @@ namespace NetSerializer
 			return dm;
 		}
 
-		/// <summary>
-		/// Create delegate that calls writer either directly, or via a trampoline
-		/// </summary>
-		public static Delegate CreateSerializeDelegate(Type paramType, TypeData data)
+#if GENERATE_DEBUGGING_ASSEMBLY
+        public static MethodBuilder GenerateStaticSerializerStub(TypeBuilder tb, Type type)
+        {
+            var mb = tb.DefineMethod("Serialize", MethodAttributes.Public | MethodAttributes.Static, null,
+                new Type[] { typeof(Serializer), typeof(Stream), type });
+            mb.DefineParameter(1, ParameterAttributes.None, "serializer");
+            mb.DefineParameter(2, ParameterAttributes.None, "stream");
+            mb.DefineParameter(3, ParameterAttributes.None, "value");
+            return mb;
+        }
+
+        public static MethodBuilder GenerateStaticDeserializerStub(TypeBuilder tb, Type type)
+        {
+            var mb = tb.DefineMethod("Deserialize", MethodAttributes.Public | MethodAttributes.Static, null,
+                new Type[] { typeof(Serializer), typeof(Stream), type.MakeByRefType() });
+            mb.DefineParameter(1, ParameterAttributes.None, "serializer");
+            mb.DefineParameter(2, ParameterAttributes.None, "stream");
+            mb.DefineParameter(3, ParameterAttributes.Out, "value");
+            return mb;
+        }
+#endif
+
+        /// <summary>
+        /// Create delegate that calls writer either directly, or via a trampoline
+        /// </summary>
+        public static Delegate CreateSerializeDelegate(Type paramType, TypeData data)
 		{
 			Type writerType = data.Type;
 

--- a/NetSerializer/ITypeSerializer.cs
+++ b/NetSerializer/ITypeSerializer.cs
@@ -18,7 +18,7 @@ namespace NetSerializer
 		/// <summary>
 		/// Returns if this TypeSerializer handles the given type
 		/// </summary>
-		bool Handles(Type type);
+		bool Handles(Serializer serializer, Type type);
 
 		/// <summary>
 		/// Return types that are needed to serialize the given type

--- a/NetSerializer/NetSerializer.csproj
+++ b/NetSerializer/NetSerializer.csproj
@@ -19,7 +19,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;GENERATE_DEBUGGING_ASSEMBLY</DefineConstants>
+    <DefineConstants>TRACE;DEBUG</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/NetSerializer/NetSerializer.csproj
+++ b/NetSerializer/NetSerializer.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>NetSerializer</RootNamespace>
     <AssemblyName>NetSerializer</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/NetSerializer/Primitives.cs
+++ b/NetSerializer/Primitives.cs
@@ -19,14 +19,14 @@ namespace NetSerializer
 	{
 		public static MethodInfo GetWritePrimitive(Type type)
 		{
-			return typeof(Primitives).GetMethod("WritePrimitive",
+			return typeof(Primitives).GetTypeInfo().GetMethod("WritePrimitive",
 				BindingFlags.Static | BindingFlags.Public | BindingFlags.ExactBinding, null,
 				new Type[] { typeof(Stream), type }, null);
 		}
 
 		public static MethodInfo GetReaderPrimitive(Type type)
 		{
-			return typeof(Primitives).GetMethod("ReadPrimitive",
+			return typeof(Primitives).GetTypeInfo().GetMethod("ReadPrimitive",
 				BindingFlags.Static | BindingFlags.Public | BindingFlags.ExactBinding, null,
 				new Type[] { typeof(Stream), type.MakeByRefType() }, null);
 		}

--- a/NetSerializer/Primitives.cs
+++ b/NetSerializer/Primitives.cs
@@ -442,10 +442,15 @@ namespace NetSerializer
 			int totalChars = value.Length;
 			int totalBytes;
 
-			fixed (char* ptr = value)
+#if DNXCORE50
+            // TODO: .NET Core 1.1 does not yet support the pointer overload of 'Encoder.GetByteCount()'
+            totalBytes = encoder.GetByteCount(value.ToCharArray(), 0, totalChars, true);
+#else
+            fixed (char* ptr = value)
 				totalBytes = encoder.GetByteCount(ptr, totalChars, true);
+#endif
 
-			WritePrimitive(stream, (uint)totalBytes + 1);
+            WritePrimitive(stream, (uint)totalBytes + 1);
 			WritePrimitive(stream, (uint)totalChars);
 
 			int p = 0;
@@ -456,14 +461,20 @@ namespace NetSerializer
 				int charsConverted;
 				int bytesConverted;
 
-				fixed (char* src = value)
+#if DNXCORE50
+                // TODO: .NET Core 1.1 does not yet support the pointer overload of 'Encoder.Convert()'
+                encoder.Convert(value.ToCharArray(), 0, totalChars - p, buf, 0, buf.Length, true,
+					out charsConverted, out bytesConverted, out completed);
+#else
+                fixed (char* src = value)
 				fixed (byte* dst = buf)
 				{
 					encoder.Convert(src + p, totalChars - p, dst, buf.Length, true,
 						out charsConverted, out bytesConverted, out completed);
 				}
+#endif
 
-				stream.Write(buf, 0, bytesConverted);
+                stream.Write(buf, 0, bytesConverted);
 
 				p += charsConverted;
 			}
@@ -538,7 +549,7 @@ namespace NetSerializer
 		}
 #endif
 
-		public static void WritePrimitive(Stream stream, byte[] value)
+        public static void WritePrimitive(Stream stream, byte[] value)
 		{
 			if (value == null)
 			{

--- a/NetSerializer/Primitives.cs
+++ b/NetSerializer/Primitives.cs
@@ -19,19 +19,27 @@ namespace NetSerializer
 	{
 		public static MethodInfo GetWritePrimitive(Type type)
 		{
-			return typeof(Primitives).GetTypeInfo().GetMethod("WritePrimitive",
-				BindingFlags.Static | BindingFlags.Public | BindingFlags.ExactBinding, null,
-				new Type[] { typeof(Stream), type }, null);
+            // .NET Core does not support all GetMethod() overloads
+            return typeof(Primitives).GetTypeInfo().GetMethod(
+                "WritePrimitive", new Type[] { typeof(Stream), type });
+
+            //return typeof(Primitives).GetTypeInfo().GetMethod("WritePrimitive",
+		    //  BindingFlags.Static | BindingFlags.Public | BindingFlags.ExactBinding, null,
+			//  new Type[] { typeof(Stream), type }, null);
 		}
 
 		public static MethodInfo GetReaderPrimitive(Type type)
 		{
-			return typeof(Primitives).GetTypeInfo().GetMethod("ReadPrimitive",
-				BindingFlags.Static | BindingFlags.Public | BindingFlags.ExactBinding, null,
-				new Type[] { typeof(Stream), type.MakeByRefType() }, null);
-		}
+            // .NET Core does not support all GetMethod() overloads
+            return typeof(Primitives).GetTypeInfo().GetMethod(
+                "ReadPrimitive", new Type[] { typeof(Stream), type.MakeByRefType() });
 
-		static uint EncodeZigZag32(int n)
+            //return typeof(Primitives).GetTypeInfo().GetMethod("ReadPrimitive",
+            //	BindingFlags.Static | BindingFlags.Public | BindingFlags.ExactBinding, null,
+            //	new Type[] { typeof(Stream), type.MakeByRefType() }, null);
+        }
+
+        static uint EncodeZigZag32(int n)
 		{
 			return (uint)((n << 1) ^ (n >> 31));
 		}

--- a/NetSerializer/Serializer.cs
+++ b/NetSerializer/Serializer.cs
@@ -121,10 +121,10 @@ namespace NetSerializer
 				if (m_runtimeTypeMap.ContainsKey(type))
 					continue;
 
-				if (type.IsAbstract || type.IsInterface)
+				if (type.GetTypeInfo().IsAbstract || type.GetTypeInfo().IsInterface)
 					continue;
 
-				if (type.ContainsGenericParameters)
+				if (type.GetTypeInfo().ContainsGenericParameters)
 					throw new NotSupportedException(String.Format("Type {0} contains generic parameters", type.FullName));
 
 				while (m_runtimeTypeIDList.ContainsTypeID(m_nextAvailableTypeID))
@@ -176,10 +176,10 @@ namespace NetSerializer
 				if (m_runtimeTypeIDList.ContainsTypeID(typeID))
 					throw new ArgumentException(String.Format("Type with typeID {0} already added", typeID));
 
-				if (type.IsAbstract || type.IsInterface)
+				if (type.GetTypeInfo().IsAbstract || type.GetTypeInfo().IsInterface)
 					throw new ArgumentException(String.Format("Type {0} is abstract or interface", type.FullName));
 
-				if (type.ContainsGenericParameters)
+				if (type.GetTypeInfo().ContainsGenericParameters)
 					throw new NotSupportedException(String.Format("Type {0} contains generic parameters", type.FullName));
 
 				ITypeSerializer serializer = GetTypeSerializer(type);
@@ -393,10 +393,10 @@ namespace NetSerializer
 			{
 				var type = stack.Pop();
 
-				if (type.IsAbstract || type.IsInterface)
+				if (type.GetTypeInfo().IsAbstract || type.GetTypeInfo().IsInterface)
 					continue;
 
-				if (type.ContainsGenericParameters)
+				if (type.GetTypeInfo().ContainsGenericParameters)
 					throw new NotSupportedException(String.Format("Type {0} contains generic parameters", type.FullName));
 
 				ITypeSerializer serializer = m_runtimeTypeMap[type].TypeSerializer;
@@ -602,106 +602,5 @@ namespace NetSerializer
 			data.ReaderDirectDelegate = Helpers.CreateDeserializeDelegate(type, data);
 			return data.ReaderDirectDelegate;
 		}
-
-
-
-#if GENERATE_DEBUGGING_ASSEMBLY
-
-		public static void GenerateDebugAssembly(IEnumerable<Type> rootTypes, Settings settings)
-		{
-			new Serializer(rootTypes, settings, true);
-		}
-
-		Serializer(IEnumerable<Type> rootTypes, Settings settings, bool debugAssembly)
-		{
-			this.Settings = settings;
-
-			if (this.Settings.CustomTypeSerializers.All(s => s is IDynamicTypeSerializer || s is IStaticTypeSerializer) == false)
-				throw new ArgumentException("TypeSerializers have to implement IDynamicTypeSerializer or  IStaticTypeSerializer");
-
-			var ab = AppDomain.CurrentDomain.DefineDynamicAssembly(new AssemblyName("NetSerializerDebug"), AssemblyBuilderAccess.RunAndSave);
-			var modb = ab.DefineDynamicModule("NetSerializerDebug.dll");
-			var tb = modb.DefineType("NetSerializer", TypeAttributes.Public);
-
-			m_runtimeTypeMap = new TypeDictionary();
-			m_runtimeTypeIDList = new TypeIDList();
-
-			lock (m_modifyLock)
-			{
-				var addedTypes = AddTypesInternal(new[] { typeof(object) }.Concat(rootTypes));
-
-				/* generate stubs */
-				foreach (var type in addedTypes.Keys)
-					GenerateDebugStubs(type, tb);
-
-				foreach (var type in addedTypes.Keys)
-					GenerateDebugBodies(type);
-			}
-
-			tb.CreateType();
-			ab.Save("NetSerializerDebug.dll");
-		}
-
-		void GenerateDebugStubs(Type type, TypeBuilder tb)
-		{
-			var data = m_runtimeTypeMap[type];
-
-			ITypeSerializer serializer = data.TypeSerializer;
-
-			MethodInfo writer;
-			MethodInfo reader;
-			bool writerNeedsInstance, readerNeedsInstance;
-
-			if (serializer is IStaticTypeSerializer)
-			{
-				var sts = (IStaticTypeSerializer)serializer;
-
-				writer = sts.GetStaticWriter(type);
-				reader = sts.GetStaticReader(type);
-
-				writerNeedsInstance = writer.GetParameters().Length == 3;
-				readerNeedsInstance = reader.GetParameters().Length == 3;
-			}
-			else if (serializer is IDynamicTypeSerializer)
-			{
-				writer = Helpers.GenerateStaticSerializerStub(tb, type);
-				reader = Helpers.GenerateStaticDeserializerStub(tb, type);
-
-				writerNeedsInstance = readerNeedsInstance = true;
-			}
-			else
-			{
-				throw new Exception();
-			}
-
-			data.WriterMethodInfo = writer;
-			data.WriterNeedsInstanceDebug = writerNeedsInstance;
-
-			data.ReaderMethodInfo = reader;
-			data.ReaderNeedsInstanceDebug = readerNeedsInstance;
-		}
-
-		void GenerateDebugBodies(Type type)
-		{
-			var data = m_runtimeTypeMap[type];
-
-			ITypeSerializer serializer = data.TypeSerializer;
-
-			var dynSer = serializer as IDynamicTypeSerializer;
-			if (dynSer == null)
-				return;
-
-			var writer = data.WriterMethodInfo as MethodBuilder;
-			if (writer == null)
-				throw new Exception();
-
-			var reader = data.ReaderMethodInfo as MethodBuilder;
-			if (reader == null)
-				throw new Exception();
-
-			dynSer.GenerateWriterMethod(this, type, writer.GetILGenerator());
-			dynSer.GenerateReaderMethod(this, type, reader.GetILGenerator());
-		}
-#endif
 	}
 }

--- a/NetSerializer/Serializer.cs
+++ b/NetSerializer/Serializer.cs
@@ -350,10 +350,10 @@ namespace NetSerializer
 
 		ITypeSerializer GetTypeSerializer(Type type)
 		{
-			var serializer = this.Settings.CustomTypeSerializers.FirstOrDefault(h => h.Handles(type));
+			var serializer = this.Settings.CustomTypeSerializers.FirstOrDefault(h => h.Handles(this,type));
 
 			if (serializer == null)
-				serializer = s_typeSerializers.FirstOrDefault(h => h.Handles(type));
+				serializer = s_typeSerializers.FirstOrDefault(h => h.Handles(this,type));
 
 			if (serializer == null)
 				throw new NotSupportedException(String.Format("No serializer for {0}", type.FullName));

--- a/NetSerializer/Serializer.cs
+++ b/NetSerializer/Serializer.cs
@@ -602,5 +602,104 @@ namespace NetSerializer
 			data.ReaderDirectDelegate = Helpers.CreateDeserializeDelegate(type, data);
 			return data.ReaderDirectDelegate;
 		}
-	}
+
+#if GENERATE_DEBUGGING_ASSEMBLY
+
+		public static void GenerateDebugAssembly(IEnumerable<Type> rootTypes, Settings settings)
+		{
+			new Serializer(rootTypes, settings, true);
+		}
+
+		Serializer(IEnumerable<Type> rootTypes, Settings settings, bool debugAssembly)
+		{
+			this.Settings = settings;
+
+			if (this.Settings.CustomTypeSerializers.All(s => s is IDynamicTypeSerializer || s is IStaticTypeSerializer) == false)
+				throw new ArgumentException("TypeSerializers have to implement IDynamicTypeSerializer or  IStaticTypeSerializer");
+
+			var ab = AppDomain.CurrentDomain.DefineDynamicAssembly(new AssemblyName("NetSerializerDebug"), AssemblyBuilderAccess.RunAndSave);
+			var modb = ab.DefineDynamicModule("NetSerializerDebug.dll");
+			var tb = modb.DefineType("NetSerializer", TypeAttributes.Public);
+
+			m_runtimeTypeMap = new TypeDictionary();
+			m_runtimeTypeIDList = new TypeIDList();
+
+			lock (m_modifyLock)
+			{
+				var addedTypes = AddTypesInternal(new[] { typeof(object) }.Concat(rootTypes));
+
+				/* generate stubs */
+				foreach (var type in addedTypes.Keys)
+					GenerateDebugStubs(type, tb);
+
+				foreach (var type in addedTypes.Keys)
+					GenerateDebugBodies(type);
+			}
+
+			tb.CreateType();
+			ab.Save("NetSerializerDebug.dll");
+		}
+
+		void GenerateDebugStubs(Type type, TypeBuilder tb)
+		{
+			var data = m_runtimeTypeMap[type];
+
+			ITypeSerializer serializer = data.TypeSerializer;
+
+			MethodInfo writer;
+			MethodInfo reader;
+			bool writerNeedsInstance, readerNeedsInstance;
+
+			if (serializer is IStaticTypeSerializer)
+			{
+				var sts = (IStaticTypeSerializer)serializer;
+
+				writer = sts.GetStaticWriter(type);
+				reader = sts.GetStaticReader(type);
+
+				writerNeedsInstance = writer.GetParameters().Length == 3;
+				readerNeedsInstance = reader.GetParameters().Length == 3;
+			}
+			else if (serializer is IDynamicTypeSerializer)
+			{
+				writer = Helpers.GenerateStaticSerializerStub(tb, type);
+				reader = Helpers.GenerateStaticDeserializerStub(tb, type);
+
+				writerNeedsInstance = readerNeedsInstance = true;
+			}
+			else
+			{
+				throw new Exception();
+			}
+
+			data.WriterMethodInfo = writer;
+			data.WriterNeedsInstanceDebug = writerNeedsInstance;
+
+			data.ReaderMethodInfo = reader;
+			data.ReaderNeedsInstanceDebug = readerNeedsInstance;
+		}
+
+		void GenerateDebugBodies(Type type)
+		{
+			var data = m_runtimeTypeMap[type];
+
+			ITypeSerializer serializer = data.TypeSerializer;
+
+			var dynSer = serializer as IDynamicTypeSerializer;
+			if (dynSer == null)
+				return;
+
+			var writer = data.WriterMethodInfo as MethodBuilder;
+			if (writer == null)
+				throw new Exception();
+
+			var reader = data.ReaderMethodInfo as MethodBuilder;
+			if (reader == null)
+				throw new Exception();
+
+			dynSer.GenerateWriterMethod(this, type, writer.GetILGenerator());
+			dynSer.GenerateReaderMethod(this, type, reader.GetILGenerator());
+		}
+#endif
+    }
 }

--- a/NetSerializer/Settings.cs
+++ b/NetSerializer/Settings.cs
@@ -18,14 +18,17 @@ namespace NetSerializer
 		/// </summary>
 		public ITypeSerializer[] CustomTypeSerializers = new ITypeSerializer[0];
 
-		/// <summary>
-		/// Support IDeserializationCallback
-		/// </summary>
-		public bool SupportIDeserializationCallback = false;
+        // .NET Core does not provide the serialization callbacks
+#if !DNXCORE50
+        /// <summary>
+        /// Support IDeserializationCallback
+        /// </summary>
+        public bool SupportIDeserializationCallback = false;
 
 		/// <summary>
 		/// Support OnSerializing, OnSerialized, OnDeserializing, OnDeserialized attributes
 		/// </summary>
 		public bool SupportSerializationCallbacks = false;
-	}
+#endif
+    }
 }

--- a/NetSerializer/Settings.cs
+++ b/NetSerializer/Settings.cs
@@ -19,9 +19,9 @@ namespace NetSerializer
 		public ITypeSerializer[] CustomTypeSerializers = new ITypeSerializer[0];
 
         // .NET Core does not provide ISerializableAttribute nor serialization callbacks
-#if !DNXCORE50
-	    public bool SupportISerializableAttribute = true;
+        public bool SupportISerializableAttribute = true;
 
+#if !DNXCORE50
         /// <summary>
         /// Support IDeserializationCallback
         /// </summary>

--- a/NetSerializer/Settings.cs
+++ b/NetSerializer/Settings.cs
@@ -18,8 +18,10 @@ namespace NetSerializer
 		/// </summary>
 		public ITypeSerializer[] CustomTypeSerializers = new ITypeSerializer[0];
 
-        // .NET Core does not provide the serialization callbacks
+        // .NET Core does not provide ISerializableAttribute nor serialization callbacks
 #if !DNXCORE50
+	    public bool SupportISerializableAttribute = true;
+
         /// <summary>
         /// Support IDeserializationCallback
         /// </summary>

--- a/NetSerializer/TypeData.cs
+++ b/NetSerializer/TypeData.cs
@@ -39,10 +39,6 @@ namespace NetSerializer
 		{
 			get
 			{
-#if GENERATE_DEBUGGING_ASSEMBLY
-				if (this.WriterMethodInfo is MethodBuilder)
-					return this.WriterNeedsInstanceDebug;
-#endif
 				return this.WriterMethodInfo.GetParameters().Length == 3;
 			}
 		}
@@ -51,19 +47,9 @@ namespace NetSerializer
 		{
 			get
 			{
-#if GENERATE_DEBUGGING_ASSEMBLY
-				if (this.ReaderMethodInfo is MethodBuilder)
-					return this.ReaderNeedsInstanceDebug;
-#endif
 				return this.ReaderMethodInfo.GetParameters().Length == 3;
 			}
 		}
-
-#if GENERATE_DEBUGGING_ASSEMBLY
-		// MethodBuilder doesn't support GetParameters(), so we need to track this separately
-		public bool WriterNeedsInstanceDebug;
-		public bool ReaderNeedsInstanceDebug;
-#endif
 
 		public bool CanCallDirect
 		{
@@ -77,10 +63,10 @@ namespace NetSerializer
 
 				var type = this.Type;
 
-				if (type.IsValueType || type.IsArray)
+				if (type.GetTypeInfo().IsValueType || type.IsArray)
 					return true;
 
-				if (type.IsSealed && (this.TypeSerializer is IStaticTypeSerializer))
+				if (type.GetTypeInfo().IsSealed && (this.TypeSerializer is IStaticTypeSerializer))
 					return true;
 
 				return false;

--- a/NetSerializer/TypeData.cs
+++ b/NetSerializer/TypeData.cs
@@ -35,23 +35,37 @@ namespace NetSerializer
 		public DeserializeDelegate<object> ReaderTrampolineDelegate;
 		public Delegate ReaderDirectDelegate;
 
-		public bool WriterNeedsInstance
-		{
-			get
-			{
-				return this.WriterMethodInfo.GetParameters().Length == 3;
-			}
-		}
+        public bool WriterNeedsInstance
+        {
+            get
+            {
+#if GENERATE_DEBUGGING_ASSEMBLY
+                if (this.WriterMethodInfo is MethodBuilder)
+                    return this.WriterNeedsInstanceDebug;
+#endif
+                return this.WriterMethodInfo.GetParameters().Length == 3;
+            }
+        }
 
-		public bool ReaderNeedsInstance
-		{
-			get
-			{
-				return this.ReaderMethodInfo.GetParameters().Length == 3;
-			}
-		}
+        public bool ReaderNeedsInstance
+        {
+            get
+            {
+#if GENERATE_DEBUGGING_ASSEMBLY
+                if (this.ReaderMethodInfo is MethodBuilder)
+                    return this.ReaderNeedsInstanceDebug;
+#endif
+                return this.ReaderMethodInfo.GetParameters().Length == 3;
+            }
+        }
 
-		public bool CanCallDirect
+#if GENERATE_DEBUGGING_ASSEMBLY
+        // MethodBuilder doesn't support GetParameters(), so we need to track this separately
+        public bool WriterNeedsInstanceDebug;
+        public bool ReaderNeedsInstanceDebug;
+#endif
+
+        public bool CanCallDirect
 		{
 			get
 			{

--- a/NetSerializer/TypeSerializers/ArraySerializer.cs
+++ b/NetSerializer/TypeSerializers/ArraySerializer.cs
@@ -17,7 +17,7 @@ namespace NetSerializer
 {
 	sealed class ArraySerializer : IDynamicTypeSerializer
 	{
-		public bool Handles(Type type)
+		public bool Handles(Serializer serializer, Type type)
 		{
 			if (!type.IsArray)
 				return false;

--- a/NetSerializer/TypeSerializers/DictionarySerializer.cs
+++ b/NetSerializer/TypeSerializers/DictionarySerializer.cs
@@ -63,7 +63,7 @@ namespace NetSerializer
 
 		public MethodInfo GetStaticReader(Type type)
 		{
-			Debug.Assert(type.IsGenericType);
+			Debug.Assert(type.GetTypeInfo().IsGenericType);
 
 			if (!type.GetTypeInfo().IsGenericType)
 				throw new Exception();

--- a/NetSerializer/TypeSerializers/DictionarySerializer.cs
+++ b/NetSerializer/TypeSerializers/DictionarySerializer.cs
@@ -18,7 +18,7 @@ namespace NetSerializer
 {
 	sealed class DictionarySerializer : IStaticTypeSerializer
 	{
-		public bool Handles(Type type)
+		public bool Handles(Serializer serializer, Type type)
 		{
 			if (!type.GetTypeInfo().IsGenericType)
 				return false;

--- a/NetSerializer/TypeSerializers/DictionarySerializer.cs
+++ b/NetSerializer/TypeSerializers/DictionarySerializer.cs
@@ -20,7 +20,7 @@ namespace NetSerializer
 	{
 		public bool Handles(Type type)
 		{
-			if (!type.IsGenericType)
+			if (!type.GetTypeInfo().IsGenericType)
 				return false;
 
 			var genTypeDef = type.GetGenericTypeDefinition();
@@ -41,9 +41,9 @@ namespace NetSerializer
 
 		public MethodInfo GetStaticWriter(Type type)
 		{
-			Debug.Assert(type.IsGenericType);
+			Debug.Assert(type.GetTypeInfo().IsGenericType);
 
-			if (!type.IsGenericType)
+			if (!type.GetTypeInfo().IsGenericType)
 				throw new Exception();
 
 			var genTypeDef = type.GetGenericTypeDefinition();
@@ -65,7 +65,7 @@ namespace NetSerializer
 		{
 			Debug.Assert(type.IsGenericType);
 
-			if (!type.IsGenericType)
+			if (!type.GetTypeInfo().IsGenericType)
 				throw new Exception();
 
 			var genTypeDef = type.GetGenericTypeDefinition();
@@ -100,7 +100,7 @@ namespace NetSerializer
 
 				var paramType = p[2].ParameterType;
 
-				if (paramType.IsGenericType == false)
+				if (paramType.GetTypeInfo().IsGenericType == false)
 					continue;
 
 				var genParamType = paramType.GetGenericTypeDefinition();
@@ -134,7 +134,7 @@ namespace NetSerializer
 
 				paramType = paramType.GetElementType();
 
-				if (paramType.IsGenericType == false)
+				if (paramType.GetTypeInfo().IsGenericType == false)
 					continue;
 
 				var genParamType = paramType.GetGenericTypeDefinition();

--- a/NetSerializer/TypeSerializers/EnumSerializer.cs
+++ b/NetSerializer/TypeSerializers/EnumSerializer.cs
@@ -20,7 +20,7 @@ namespace NetSerializer
 	{
 		public bool Handles(Type type)
 		{
-			return type.IsEnum;
+			return type.GetTypeInfo().IsEnum;
 		}
 
 		public IEnumerable<Type> GetSubtypes(Type type)
@@ -32,7 +32,7 @@ namespace NetSerializer
 
 		public MethodInfo GetStaticWriter(Type type)
 		{
-			Debug.Assert(type.IsEnum);
+			Debug.Assert(type.GetTypeInfo().IsEnum);
 
 			var underlyingType = Enum.GetUnderlyingType(type);
 
@@ -41,7 +41,7 @@ namespace NetSerializer
 
 		public MethodInfo GetStaticReader(Type type)
 		{
-			Debug.Assert(type.IsEnum);
+			Debug.Assert(type.GetTypeInfo().IsEnum);
 
 			var underlyingType = Enum.GetUnderlyingType(type);
 

--- a/NetSerializer/TypeSerializers/EnumSerializer.cs
+++ b/NetSerializer/TypeSerializers/EnumSerializer.cs
@@ -18,7 +18,7 @@ namespace NetSerializer
 {
 	sealed class EnumSerializer : IStaticTypeSerializer
 	{
-		public bool Handles(Type type)
+		public bool Handles(Serializer serializer, Type type)
 		{
 			return type.GetTypeInfo().IsEnum;
 		}

--- a/NetSerializer/TypeSerializers/GenericSerializer.cs
+++ b/NetSerializer/TypeSerializers/GenericSerializer.cs
@@ -19,17 +19,21 @@ namespace NetSerializer
 {
 	sealed class GenericSerializer : IDynamicTypeSerializer
 	{
-		public bool Handles(Type type)
+		public bool Handles(Serializer serializer, Type type)
 		{
             // .NET Core does not include the SerializableAttribute
+#if !DNXCORE50
+		    if (serializer.Settings.SupportISerializableAttribute)
+		    {
+		        if (!type.IsSerializable)
+		            throw new NotSupportedException(String.Format("Type {0} is not marked as Serializable", type.FullName));
 
-			//if (!type.IsSerializable)
-			//	throw new NotSupportedException(String.Format("Type {0} is not marked as Serializable", type.FullName));
-
-			//if (typeof(System.Runtime.Serialization.ISerializable).IsAssignableFrom(type))
-			//	throw new NotSupportedException(String.Format("Cannot serialize {0}: ISerializable not supported", type.FullName));
-
-			return true;
+		        if (typeof(System.Runtime.Serialization.ISerializable).IsAssignableFrom(type))
+		            throw new NotSupportedException(String.Format("Cannot serialize {0}: ISerializable not supported",
+		                type.FullName));
+		    }
+#endif
+            return true;
 		}
 
 		public IEnumerable<Type> GetSubtypes(Type type)

--- a/NetSerializer/TypeSerializers/GenericSerializer.cs
+++ b/NetSerializer/TypeSerializers/GenericSerializer.cs
@@ -190,12 +190,16 @@ namespace NetSerializer
 			{
 				if (typeof(System.Runtime.Serialization.IDeserializationCallback).IsAssignableFrom(type))
 				{
-					var miOnDeserialization = typeof(System.Runtime.Serialization.IDeserializationCallback)
-                        .GetTypeInfo().GetMethod("OnDeserialization",
-											BindingFlags.Instance | BindingFlags.Public,
-											null, new[] { typeof(Object) }, null);
+                    // .NET Core does not support all GetMethod() overloads
+                    var miOnDeserialization = typeof(System.Runtime.Serialization.IDeserializationCallback)
+                        .GetTypeInfo().GetMethod("OnDeserialization", new[] { typeof(Object) });
 
-					il.Emit(OpCodes.Ldarg_2);
+                    //var miOnDeserialization = typeof(System.Runtime.Serialization.IDeserializationCallback)
+                    //    .GetTypeInfo().GetMethod("OnDeserialization",
+                    //                        BindingFlags.Instance | BindingFlags.Public,
+                    //                        null, new[] { typeof(Object) }, null);
+
+                    il.Emit(OpCodes.Ldarg_2);
 					il.Emit(OpCodes.Ldnull);
 					il.Emit(OpCodes.Constrained, type);
 					il.Emit(OpCodes.Callvirt, miOnDeserialization);

--- a/NetSerializer/TypeSerializers/NoOpSerializer.cs
+++ b/NetSerializer/TypeSerializers/NoOpSerializer.cs
@@ -32,7 +32,7 @@ namespace NetSerializer
 		public bool Handles(Type type)
 		{
 			if (m_handleSubclasses)
-				return m_types.Any(t => type.IsSubclassOf(t));
+				return m_types.Any(t => type.GetTypeInfo().IsSubclassOf(t));
 			else
 				return m_types.Contains(type);
 		}

--- a/NetSerializer/TypeSerializers/NoOpSerializer.cs
+++ b/NetSerializer/TypeSerializers/NoOpSerializer.cs
@@ -29,7 +29,7 @@ namespace NetSerializer
 			m_handleSubclasses = handleSubclasses;
 		}
 
-		public bool Handles(Type type)
+		public bool Handles(Serializer serializer, Type type)
 		{
 			if (m_handleSubclasses)
 				return m_types.Any(t => type.GetTypeInfo().IsSubclassOf(t));

--- a/NetSerializer/TypeSerializers/NullableSerializer.cs
+++ b/NetSerializer/TypeSerializers/NullableSerializer.cs
@@ -15,7 +15,7 @@ namespace NetSerializer
 {
 	sealed class NullableSerializer : IDynamicTypeSerializer
 	{
-		public bool Handles(Type type)
+		public bool Handles(Serializer serializer, Type type)
 		{
 			if (!type.GetTypeInfo().IsGenericType)
 				return false;

--- a/NetSerializer/TypeSerializers/NullableSerializer.cs
+++ b/NetSerializer/TypeSerializers/NullableSerializer.cs
@@ -17,7 +17,7 @@ namespace NetSerializer
 	{
 		public bool Handles(Type type)
 		{
-			if (!type.IsGenericType)
+			if (!type.GetTypeInfo().IsGenericType)
 				return false;
 
 			var genTypeDef = type.GetGenericTypeDefinition();

--- a/NetSerializer/TypeSerializers/ObjectSerializer.cs
+++ b/NetSerializer/TypeSerializers/ObjectSerializer.cs
@@ -16,7 +16,7 @@ namespace NetSerializer
 {
 	sealed class ObjectSerializer : IStaticTypeSerializer
 	{
-		public bool Handles(Type type)
+		public bool Handles(Serializer serializer, Type type)
 		{
 			return type == typeof(object);
 		}

--- a/NetSerializer/TypeSerializers/PrimitivesSerializer.cs
+++ b/NetSerializer/TypeSerializers/PrimitivesSerializer.cs
@@ -31,7 +31,7 @@ namespace NetSerializer
 				typeof(Decimal),
 			};
 
-		public bool Handles(Type type)
+		public bool Handles(Serializer serializer, Type type)
 		{
 			return s_primitives.Contains(type);
 		}

--- a/NetSerializer/project.json
+++ b/NetSerializer/project.json
@@ -1,0 +1,31 @@
+{
+    "dependencies":{
+    },
+
+    "frameworks": {
+        "net452": { },
+        "netcoreapp1.0": {
+            "buildOptions": {
+                "define": ["DNXCORE50"]
+            },
+            "imports": "dnxcore50",
+            "dependencies": {
+                "Microsoft.NETCore.App": {
+                    "type": "platform",
+                    "version": "1.0.0"
+                },
+                "System.Reflection.Extensions": "4.0.1",
+                "System.Reflection.Primitives" : "4.0.1",
+                "System.Reflection.Emit.ILGeneration" : "4.0.1",
+                "System.Reflection.Emit.Lightweight" : "4.0.1",
+                "System.Reflection.TypeExtensions": "4.1.0"
+            }
+        }
+    },
+    
+    "runtimes": { "win": { } },
+
+    "buildOptions": {
+        "allowUnsafe": true
+    }
+}

--- a/PrimitiveTest/PrimitiveTest.csproj
+++ b/PrimitiveTest/PrimitiveTest.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>PrimitiveTest</RootNamespace>
     <AssemblyName>PrimitiveTest</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/PrimitiveTest/app.config
+++ b/PrimitiveTest/app.config
@@ -1,3 +1,3 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2"/></startup></configuration>

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The main pros of NetSerializer are:
 - No dynamic type lookup for primitive types, structs or sealed classes, so
   deserialization is faster
 - No extra attributes needed (like DataContract/Member), just add the standard
-  [Serializable]
+  [Serializable] or even no attribute at all.
 - Thread safe without locks
 - The data is written to the stream and read from the stream directly, without
   the need for temporary buffers

--- a/Test/CustomSerializers.cs
+++ b/Test/CustomSerializers.cs
@@ -10,7 +10,7 @@ namespace Test
 {
 	class TriDimArrayCustomSerializer : IStaticTypeSerializer
 	{
-		public bool Handles(Type type)
+		public bool Handles(Serializer serializer, Type type)
 		{
 			return type == typeof(int[,,]);
 		}

--- a/Test/Test.csproj
+++ b/Test/Test.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Test</RootNamespace>
     <AssemblyName>Test</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/Test/app.config
+++ b/Test/app.config
@@ -1,3 +1,3 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2"/></startup></configuration>


### PR DESCRIPTION
.NET Core is not fully backward compatibility, and it takes some effort to get `NetSerializer` working on this platform. Here is an upgrade for .NET Core. Salient points:

* Dual support .NET 4.5 and .NET Core
* Compile flag `DNXCORE50` introduced to support .NET Core
* `[Serializable]` behavior disabled in .NET Core (because attribute does not exist)
* Pending quirk related to `Encoder` as pointer overloads have not been ported yet.