### PR TITLE
Callbacks to get information about (de)serialized types

### DIFF
--- a/NetSerializer/Settings.cs
+++ b/NetSerializer/Settings.cs
@@ -14,6 +14,16 @@ namespace NetSerializer
 	public class Settings
 	{
 		/// <summary>
+		/// Gets called when an object is going to be deserialized.
+		/// </summary>
+		public Action<uint> BeforeDeserializingObjectWithTypeId;
+        
+		/// <summary>
+		/// Gets called when an object is going to be serialized.
+		/// </summary>
+		public Action<Type> BeforeSerializingObjectOfType;
+		
+		/// <summary>
 		/// Array of custom TypeSerializers
 		/// </summary>
 		public ITypeSerializer[] CustomTypeSerializers = new ITypeSerializer[0];

--- a/NetSerializer/TypeSerializers/ObjectSerializer.cs
+++ b/NetSerializer/TypeSerializers/ObjectSerializer.cs
@@ -46,6 +46,8 @@ namespace NetSerializer
 
 			var type = ob.GetType();
 
+			serializer.Settings.BeforeSerializingObjectOfType?.Invoke(type);
+
 			SerializeDelegate<object> del;
 
 			uint id = serializer.GetTypeIdAndSerializer(type, out del);
@@ -75,6 +77,8 @@ namespace NetSerializer
 				ob = new object();
 				return;
 			}
+			
+			serializer.Settings.BeforeDeserializingObjectWithTypeId?.Invoke(id);
 
 			var del = serializer.GetDeserializeTrampolineFromId(id);
 			del(serializer, stream, out ob);

--- a/Test/Program.cs
+++ b/Test/Program.cs
@@ -41,6 +41,22 @@ namespace Test
 
 			foreach (var thread in threads)
 				thread.Join();
+			
+			Console.WriteLine();
+			Console.WriteLine("Serialized objects of types:");
+			foreach (var type in Tester.SerializedTypes.OrderBy(x => x.FullName))
+			{
+				Console.WriteLine(type.FullName);
+			}
+
+			Console.WriteLine();
+			Console.WriteLine("Deserialized objects with type ids:");
+			foreach (var id in Tester.DeserializedTypeIds.OrderBy(x => x))
+			{
+				Console.WriteLine(id);
+			}
+
+			Console.ReadKey();
 		}
 
 		static bool ParseArgs(string[] args)

--- a/Test/Tester.cs
+++ b/Test/Tester.cs
@@ -9,6 +9,14 @@ namespace Test
 {
 	class Tester
 	{
+		private static HashSet<Type> m_serializedTypes = new HashSet<Type>();
+		
+		private static HashSet<uint> m_deserializedTypeIds = new HashSet<uint>();
+		
+		public static IEnumerable<Type> SerializedTypes => m_serializedTypes;
+		
+		public static IEnumerable<uint> DeserializedTypeIds => m_deserializedTypeIds;
+		
 		public static NS.Serializer CreateSerializer()
 		{
 			var types = GetKnownTypes().ToArray();
@@ -18,6 +26,8 @@ namespace Test
 			var settings = new NS.Settings()
 			{
 				CustomTypeSerializers = new NS.ITypeSerializer[] { new TriDimArrayCustomSerializer() },
+				BeforeSerializingObjectOfType = type => m_serializedTypes.Add(type),
+				BeforeDeserializingObjectWithTypeId = id => m_deserializedTypeIds.Add(id)
 			};
 
 			var serializer = new NS.Serializer(types, settings);


### PR DESCRIPTION
Added callback properties to Settings class which get called from the ObjectSerializer before an object gets serialized or deserialized.
These callbacks can be used e.g. to log actually used types or to register types on demand. The later can be used when there are two instances of the serializer (because they are in different processes or in a client-server environment) to inform the counterpart about registrations.