### PR TITLE
Optimize string (de)serialization on .NET Core.

### DIFF
--- a/NetSerializer/NetSerializer.csproj
+++ b/NetSerializer/NetSerializer.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net45;netcoreapp3.0</TargetFrameworks>
     <Description>A very fast and minimal serializer</Description>
     <Company>Tomi Valkeinen</Company>
     <Copyright>Copyright © 2012-2019 Tomi Valkeinen</Copyright>

--- a/NetSerializer/Primitives.cs
+++ b/NetSerializer/Primitives.cs
@@ -363,6 +363,7 @@ namespace NetSerializer
 			}
 		}
 
+		// We cache the delegate in a static here to avoid a delegate allocation on every call to ReadPrimitive.
 		private static readonly SpanAction<char, (int, Stream)> _stringSpanRead = StringSpanRead;
 
 		public static void ReadPrimitive(Stream stream, out string value)

--- a/NetSerializer/Primitives.cs
+++ b/NetSerializer/Primitives.cs
@@ -356,9 +356,7 @@ namespace NetSerializer
 				stream.Write(buf.Slice(0, wrote));
 				totalRead += read;
 				if (read >= totalChars)
-				{
 					break;
-				}
 
 				span = span[read..];
 				totalChars -= read;
@@ -394,9 +392,7 @@ namespace NetSerializer
 		{
 			Span<byte> buf = stackalloc byte[StringByteBufferLength];
 
-			// ReSharper disable VariableHidesOuterVariable
 			var (totalBytes, stream) = tuple;
-			// ReSharper restore VariableHidesOuterVariable
 
 			var totalBytesRead = 0;
 			var totalCharsRead = 0;
@@ -408,7 +404,8 @@ namespace NetSerializer
 				var bytesReadLeft = Math.Min(buf.Length, bytesLeft);
 				var writeSlice = buf.Slice(writeBufStart, bytesReadLeft - writeBufStart);
 				var bytesInBuffer = stream.Read(writeSlice);
-				if (bytesInBuffer == 0) throw new EndOfStreamException();
+				if (bytesInBuffer == 0)
+					throw new EndOfStreamException();
 
 				var readFromStream = bytesInBuffer + writeBufStart;
 				var final = readFromStream == bytesLeft;


### PR DESCRIPTION
This new method makes use of `stackalloc`, `String.Create` and `System.Text.Unicode.Utf8` to improve performance.
Bonus points: no unsafe code, no thread local, all spans.
It allocates no less than it has to (only the string returned on read, no alloc on write) and beats the other 2 implementation almost universally (it's slightly slower than the NO_UNSAFE read on larger string sizes but has much reduced (optimal) allocations so I'd say it's worth it).

Some of these improvements (`stackalloc`, `String.Create`, spans) could be made available in NS2.1 aswell but I didn't want to create a *fourth* version of this method or remove the .NET4.5 support so didn't bother to.

Benchmark results (core is new, Unsafe is old unsafe path, slow is old safe path)

|           Method | StringLength |      Mean |    Error |    StdDev |    Median |  Gen 0 |  Gen 1 | Gen 2 | Allocated |
|----------------- |------------- |----------:|---------:|----------:|----------:|-------:|-------:|------:|----------:|
|   BenchWriteCore |            8 |  58.45 ns | 0.222 ns |  0.208 ns |  58.42 ns |      - |      - |     - |         - |
|    BenchReadCore |            8 |  74.53 ns | 0.386 ns |  0.342 ns |  74.59 ns | 0.0085 |      - |     - |      40 B |
| BenchWriteUnsafe |            8 |  78.31 ns | 0.303 ns |  0.283 ns |  78.28 ns |      - |      - |     - |         - |
|  BenchReadUnsafe |            8 |  74.85 ns | 0.677 ns |  0.566 ns |  74.86 ns | 0.0085 |      - |     - |      40 B |
|   BenchWriteSlow |            8 |  98.04 ns | 1.860 ns |  1.740 ns |  97.20 ns | 0.0272 |      - |     - |     128 B |
|    BenchReadSlow |            8 | 106.72 ns | 0.663 ns |  0.620 ns | 106.66 ns | 0.0356 |      - |     - |     168 B |
|   BenchWriteCore |           64 |  71.23 ns | 0.312 ns |  0.260 ns |  71.24 ns |      - |      - |     - |         - |
|    BenchReadCore |           64 |  85.97 ns | 2.004 ns |  2.534 ns |  85.88 ns | 0.0323 |      - |     - |     152 B |
| BenchWriteUnsafe |           64 |  89.64 ns | 1.816 ns |  2.983 ns |  88.69 ns |      - |      - |     - |         - |
|  BenchReadUnsafe |           64 |  89.28 ns | 1.738 ns |  2.321 ns |  88.77 ns | 0.0323 |      - |     - |     152 B |
|   BenchWriteSlow |           64 | 117.58 ns | 2.358 ns |  5.605 ns | 116.37 ns | 0.0391 |      - |     - |     184 B |
|    BenchReadSlow |           64 | 128.66 ns | 2.582 ns |  3.703 ns | 128.07 ns | 0.0713 |      - |     - |     336 B |
|   BenchWriteCore |          256 |  97.12 ns | 1.946 ns |  2.853 ns |  95.64 ns |      - |      - |     - |         - |
|    BenchReadCore |          256 | 120.61 ns | 1.096 ns |  1.025 ns | 120.68 ns | 0.1137 |      - |     - |     536 B |
| BenchWriteUnsafe |          256 | 121.21 ns | 2.467 ns |  6.368 ns | 120.10 ns |      - |      - |     - |         - |
|  BenchReadUnsafe |          256 | 160.08 ns | 3.184 ns |  6.922 ns | 160.79 ns | 0.2277 | 0.0002 |     - |    1072 B |
|   BenchWriteSlow |          256 | 162.01 ns | 3.262 ns |  5.882 ns | 160.92 ns | 0.0799 |      - |     - |     376 B |
|    BenchReadSlow |          256 | 170.75 ns | 3.690 ns |  6.063 ns | 168.13 ns | 0.1938 |      - |     - |     912 B |
|   BenchWriteCore |         1024 | 297.28 ns | 4.080 ns |  3.616 ns | 296.40 ns |      - |      - |     - |         - |
|    BenchReadCore |         1024 | 341.15 ns | 6.852 ns | 16.935 ns | 332.62 ns | 0.4401 |      - |     - |    2072 B |
| BenchWriteUnsafe |         1024 | 497.22 ns | 6.097 ns |  5.405 ns | 494.93 ns |      - |      - |     - |         - |
|  BenchReadUnsafe |         1024 | 486.59 ns | 5.282 ns |  4.941 ns | 485.26 ns | 0.8802 | 0.0029 |     - |    4144 B |
|   BenchWriteSlow |         1024 | 296.05 ns | 1.675 ns |  1.484 ns | 295.56 ns | 0.2427 |      - |     - |    1144 B |
|    BenchReadSlow |         1024 | 320.13 ns | 1.828 ns |  1.527 ns | 320.17 ns | 0.6833 |      - |     - |    3216 B |

Some tests I wrote: https://github.com/space-wizards/RobustToolbox/blob/6a62b618dc8e33572b24b9efb2736be074a95e5f/Robust.UnitTesting/Shared/Serialization/NetSerializer_Test.cs#L98

<details>
  <summary>Benchmark code</summary>

```cs
using System;
using System.Buffers;
using System.Diagnostics;
using System.IO;
using System.Text;
using System.Text.Unicode;
using BenchmarkDotNet.Attributes;
using Lidgren.Network;
using NetSerializer;

namespace Content.Benchmarks
{
    [MemoryDiagnoser]
    public class NetSerializerStringBenchmark
    {
        private const int StringByteBufferLength = 256;
        private const int StringCharBufferLength = 128;

        private string _toSerialize;

        [Params(8, 64, 256, 1024)]
        public int StringLength { get; set; }

        private readonly MemoryStream _outputStream = new MemoryStream(2048);
        private readonly MemoryStream _inputStream = new MemoryStream(2048);

        [GlobalSetup]
        public void Setup()
        {
            Span<byte> buf = stackalloc byte[StringLength / 2];
            new Random().NextBytes(buf);
            _toSerialize = NetUtility.ToHexString(buf);
            Primitives.WritePrimitive(_inputStream, _toSerialize);
        }

        [Benchmark]
        public void BenchWriteCore()
        {
            _outputStream.Position = 0;
            WritePrimitiveCore(_outputStream, _toSerialize);
        }

        [Benchmark]
        public void BenchReadCore()
        {
            _inputStream.Position = 0;
            ReadPrimitiveCore(_inputStream, out string _);
        }

        [Benchmark]
        public void BenchWriteUnsafe()
        {
            _outputStream.Position = 0;
            WritePrimitiveUnsafe(_outputStream, _toSerialize);
        }

        [Benchmark]
        public void BenchReadUnsafe()
        {
            _inputStream.Position = 0;
            ReadPrimitiveUnsafe(_inputStream, out string _);
        }

        [Benchmark]
        public void BenchWriteSlow()
        {
            _outputStream.Position = 0;
            WritePrimitiveSlow(_outputStream, _toSerialize);
        }

        [Benchmark]
        public void BenchReadSlow()
        {
            _inputStream.Position = 0;
            ReadPrimitiveSlow(_inputStream, out string _);
        }

		public static void WritePrimitiveCore(Stream stream, string value)
		{
			if (value == null)
			{
				Primitives.WritePrimitive(stream, (uint)0);
				return;
			}

			if (value.Length == 0)
			{
				Primitives.WritePrimitive(stream, (uint)1);
				return;
			}

			Span<byte> buf = stackalloc byte[StringByteBufferLength];

			var totalChars = value.Length;
			var totalBytes = Encoding.UTF8.GetByteCount(value);

			Primitives.WritePrimitive(stream, (uint)totalBytes + 1);
			Primitives.WritePrimitive(stream, (uint)totalChars);

			var totalRead = 0;
			ReadOnlySpan<char> span = value;
			for (;;)
			{
				var finalChunk = totalRead + totalChars >= totalChars;
				Utf8.FromUtf16(span, buf, out var read, out var wrote, isFinalBlock: finalChunk);
				stream.Write(buf.Slice(0, wrote));
				totalRead += read;
				if (read >= totalChars)
				{
					break;
				}

				span = span[read..];
				totalChars -= read;
			}
		}

		private static readonly SpanAction<char, (int, Stream)> _stringSpanRead = StringSpanRead;

		public static void ReadPrimitiveCore(Stream stream, out string value)
		{
			Primitives.ReadPrimitive(stream, out uint totalBytes);

			if (totalBytes == 0)
			{
				value = null;
				return;
			}

			if (totalBytes == 1)
			{
				value = string.Empty;
				return;
			}

			totalBytes -= 1;

            Primitives.ReadPrimitive(stream, out uint totalChars);

			value = string.Create((int) totalChars, ((int) totalBytes, stream), _stringSpanRead);
		}

		private static void StringSpanRead(Span<char> span, (int totalBytes, Stream stream) tuple)
		{
			Span<byte> buf = stackalloc byte[StringByteBufferLength];

			// ReSharper disable VariableHidesOuterVariable
			var (totalBytes, stream) = tuple;
			// ReSharper restore VariableHidesOuterVariable

			var totalBytesRead = 0;
			var totalCharsRead = 0;
			var writeBufStart = 0;

			while (totalBytesRead < totalBytes)
			{
				var bytesLeft = totalBytes - totalBytesRead;
				var bytesReadLeft = Math.Min(buf.Length, bytesLeft);
				var writeSlice = buf.Slice(writeBufStart, bytesReadLeft - writeBufStart);
				var bytesInBuffer = stream.Read(writeSlice);
				if (bytesInBuffer == 0) throw new EndOfStreamException();

				var readFromStream = bytesInBuffer + writeBufStart;
				var final = readFromStream == bytesLeft;
				var status = Utf8.ToUtf16(buf[..readFromStream], span[totalCharsRead..], out var bytesRead, out var charsRead, isFinalBlock: final);

				totalBytesRead += bytesRead;
				totalCharsRead += charsRead;
				writeBufStart = 0;

				if (status == OperationStatus.DestinationTooSmall)
				{
					// Malformed data?
					throw new InvalidDataException();
				}

				if (status == OperationStatus.NeedMoreData)
				{
					// We got cut short in the middle of a multi-byte UTF-8 sequence.
					// So we need to move it to the bottom of the span, then read the next bit *past* that.
					// This copy should be fine because we're only ever gonna be copying up to 4 bytes
					// from the end of the buffer to the start.
					// So no chance of overlap.
					buf[bytesRead..].CopyTo(buf);
					writeBufStart = bytesReadLeft - bytesRead;
					continue;
				}

				Debug.Assert(status == OperationStatus.Done);
			}
		}

		public static void WritePrimitiveSlow(Stream stream, string value)
		{
			if (value == null)
			{
                Primitives.WritePrimitive(stream, (uint)0);
				return;
			}
			else if (value.Length == 0)
			{
                Primitives.WritePrimitive(stream, (uint)1);
				return;
			}

			var encoding = new UTF8Encoding(false, true);

			int len = encoding.GetByteCount(value);

            Primitives.WritePrimitive(stream, (uint)len + 1);
			Primitives.WritePrimitive(stream, (uint)value.Length);

			var buf = new byte[len];

			encoding.GetBytes(value, 0, value.Length, buf, 0);

			stream.Write(buf, 0, len);
		}

		public static void ReadPrimitiveSlow(Stream stream, out string value)
		{
			uint len;
			Primitives.ReadPrimitive(stream, out len);

			if (len == 0)
			{
				value = null;
				return;
			}
			else if (len == 1)
			{
				value = string.Empty;
				return;
			}

			uint totalChars;
            Primitives.ReadPrimitive(stream, out totalChars);

			len -= 1;

			var encoding = new UTF8Encoding(false, true);

			var buf = new byte[len];

			int l = 0;

			while (l < len)
			{
				int r = stream.Read(buf, l, (int)len - l);
				if (r == 0)
					throw new EndOfStreamException();
				l += r;
			}

			value = encoding.GetString(buf);
		}

        sealed class StringHelper
		{
			public StringHelper()
			{
				this.Encoding = new UTF8Encoding(false, true);
			}

			Encoder m_encoder;
			Decoder m_decoder;

			byte[] m_byteBuffer;
			char[] m_charBuffer;

			public UTF8Encoding Encoding { get; private set; }
			public Encoder Encoder { get { if (m_encoder == null) m_encoder = this.Encoding.GetEncoder(); return m_encoder; } }
			public Decoder Decoder { get { if (m_decoder == null) m_decoder = this.Encoding.GetDecoder(); return m_decoder; } }

			public byte[] ByteBuffer { get { if (m_byteBuffer == null) m_byteBuffer = new byte[StringByteBufferLength]; return m_byteBuffer; } }
			public char[] CharBuffer { get { if (m_charBuffer == null) m_charBuffer = new char[StringCharBufferLength]; return m_charBuffer; } }
		}

		[ThreadStatic]
		static StringHelper s_stringHelper;

		public unsafe static void WritePrimitiveUnsafe(Stream stream, string value)
		{
			if (value == null)
			{
				Primitives.WritePrimitive(stream, (uint)0);
				return;
			}
			else if (value.Length == 0)
			{
                Primitives.WritePrimitive(stream, (uint)1);
				return;
			}

			var helper = s_stringHelper;
			if (helper == null)
				s_stringHelper = helper = new StringHelper();

			var encoder = helper.Encoder;
			var buf = helper.ByteBuffer;

			int totalChars = value.Length;
			int totalBytes;

			fixed (char* ptr = value)
				totalBytes = encoder.GetByteCount(ptr, totalChars, true);

			Primitives.WritePrimitive(stream, (uint)totalBytes + 1);
			Primitives.WritePrimitive(stream, (uint)totalChars);

			int p = 0;
			bool completed = false;

			while (completed == false)
			{
				int charsConverted;
				int bytesConverted;

				fixed (char* src = value)
				fixed (byte* dst = buf)
				{
					encoder.Convert(src + p, totalChars - p, dst, buf.Length, true,
						out charsConverted, out bytesConverted, out completed);
				}

				stream.Write(buf, 0, bytesConverted);

				p += charsConverted;
			}
		}

		public static void ReadPrimitiveUnsafe(Stream stream, out string value)
		{
			uint totalBytes;
			Primitives.ReadPrimitive(stream, out totalBytes);

			if (totalBytes == 0)
			{
				value = null;
				return;
			}
			else if (totalBytes == 1)
			{
				value = string.Empty;
				return;
			}

			totalBytes -= 1;

			uint totalChars;
			Primitives.ReadPrimitive(stream, out totalChars);

			var helper = s_stringHelper;
			if (helper == null)
				s_stringHelper = helper = new StringHelper();

			var decoder = helper.Decoder;
			var buf = helper.ByteBuffer;
			char[] chars;
			if (totalChars <= StringCharBufferLength)
				chars = helper.CharBuffer;
			else
				chars = new char[totalChars];

			int streamBytesLeft = (int)totalBytes;

			int cp = 0;

			while (streamBytesLeft > 0)
			{
				int bytesInBuffer = stream.Read(buf, 0, Math.Min(buf.Length, streamBytesLeft));
				if (bytesInBuffer == 0)
					throw new EndOfStreamException();

				streamBytesLeft -= bytesInBuffer;
				bool flush = streamBytesLeft == 0 ? true : false;

				bool completed = false;

				int p = 0;

				while (completed == false)
				{
					int charsConverted;
					int bytesConverted;

					decoder.Convert(buf, p, bytesInBuffer - p,
						chars, cp, (int)totalChars - cp,
						flush,
						out bytesConverted, out charsConverted, out completed);

					p += bytesConverted;
					cp += charsConverted;
				}
			}

			value = new string(chars, 0, (int)totalChars);
		}
    }
}
```

</details>