### PR TITLE
Improve float serialization, add .NET 5 Half support.

### DIFF
--- a/NetSerializer.UnitTests/HalfTest.cs
+++ b/NetSerializer.UnitTests/HalfTest.cs
@@ -1,0 +1,49 @@
+#if NET5_0
+using System;
+using System.IO;
+using NUnit.Framework;
+
+namespace NetSerializer.UnitTests
+{
+	[TestFixture]
+	[TestOf(typeof(Primitives))]
+	[Parallelizable(ParallelScope.All)]
+	public class HalfTest
+	{
+		[Test]
+		public void Test()
+		{
+			var serializer = new Serializer(new[] {typeof(SerializationType)});
+
+			var stream = new MemoryStream();
+			var obj = new SerializationType
+			{
+				R = (Half) 0,
+				G = (Half) 12.34,
+				B = (Half) 0.1,
+				A = Half.PositiveInfinity,
+			};
+
+			serializer.Serialize(stream, obj);
+
+			stream.Position = 0;
+
+			var read = (SerializationType) serializer.Deserialize(stream);
+
+			Assert.That(read.R, Is.EqualTo(obj.R));
+			Assert.That(read.G, Is.EqualTo(obj.G));
+			Assert.That(read.B, Is.EqualTo(obj.B));
+			Assert.That(read.A, Is.EqualTo(obj.A));
+		}
+
+		[Serializable]
+		private class SerializationType
+		{
+			public Half R;
+			public Half G;
+			public Half B;
+			public Half A;
+		}
+	}
+}
+#endif

--- a/NetSerializer.UnitTests/NetSerializer.UnitTests.csproj
+++ b/NetSerializer.UnitTests/NetSerializer.UnitTests.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFrameworks>net45;netcoreapp3.1;net5.0</TargetFrameworks>
+
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="NUnit" Version="3.12.0" />
+        <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+        <PackageReference Include="NUnit.Analyzers" Version="0.5.0" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\NetSerializer\NetSerializer.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0">
+        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        <PrivateAssets>all</PrivateAssets>
+      </PackageReference>
+    </ItemGroup>
+</Project>

--- a/NetSerializer.UnitTests/PrimitivesTest.cs
+++ b/NetSerializer.UnitTests/PrimitivesTest.cs
@@ -9,6 +9,33 @@ namespace NetSerializer.UnitTests
 	[Parallelizable(ParallelScope.All)]
 	public class PrimitivesTest
 	{
+#if NET5_0
+#if NO_UNSAFE
+        [Ignore("Float and half tests are inacurrate due to rounding when NO_UNSAFE is enabled.")]
+#endif
+        [Test]
+        [TestCase(0)]
+        [TestCase(1)]
+        [TestCase(123.4)]
+        [TestCase(0.01)]
+        [TestCase(double.PositiveInfinity)]
+        [TestCase(double.NegativeInfinity)]
+        [TestCase(double.NaN)]
+        public void TestHalf(double val)
+        {
+        	// Can't stick Half values in attributes so have to do this.
+        	var half = (Half) val;
+
+        	var stream = new MemoryStream();
+        	Primitives.WritePrimitive(stream, half);
+
+        	stream.Position = 0;
+
+        	Primitives.ReadPrimitive(new ByteStream(stream), out Half read);
+        	Assert.That(read, Is.EqualTo(half));
+        }
+#endif
+
 #if NO_UNSAFE
 		[Ignore("Float tests are inacurrate due to rounding when NO_UNSAFE is enabled.")]
 #endif

--- a/NetSerializer.UnitTests/PrimitivesTest.cs
+++ b/NetSerializer.UnitTests/PrimitivesTest.cs
@@ -1,0 +1,103 @@
+using System;
+using System.IO;
+using NUnit.Framework;
+
+namespace NetSerializer.UnitTests
+{
+	[TestFixture]
+	[TestOf(typeof(Primitives))]
+	[Parallelizable(ParallelScope.All)]
+	public class PrimitivesTest
+	{
+#if NO_UNSAFE
+		[Ignore("Float tests are inacurrate due to rounding when NO_UNSAFE is enabled.")]
+#endif
+		[Test]
+		[TestCase(0)]
+		[TestCase(1)]
+		[TestCase(123.4f)]
+		[TestCase(0.01f)]
+		[TestCase(float.PositiveInfinity)]
+		[TestCase(float.NegativeInfinity)]
+		[TestCase(float.NaN)]
+		public void TestSingle(float val)
+		{
+			var stream = new MemoryStream();
+			Primitives.WritePrimitive(stream, val);
+
+			stream.Position = 0;
+
+			Primitives.ReadPrimitive(new ByteStream(stream), out float read);
+			Assert.That(read, Is.EqualTo(val));
+		}
+
+		[Test]
+		[TestCase(0)]
+		[TestCase(1)]
+		[TestCase(123.4)]
+		[TestCase(0.01)]
+		[TestCase(float.PositiveInfinity)]
+		[TestCase(float.NegativeInfinity)]
+		[TestCase(float.NaN)]
+		public void TestDouble(double val)
+		{
+			var stream = new MemoryStream();
+			Primitives.WritePrimitive(stream, val);
+
+			stream.Position = 0;
+
+			Primitives.ReadPrimitive(new ByteStream(stream), out double read);
+			Assert.That(read, Is.EqualTo(val));
+		}
+
+		// Stream wrapper that only reads one byte at a time to test the reading code.
+		private sealed class ByteStream : Stream
+		{
+			private readonly Stream _parent;
+
+			public ByteStream(Stream parent)
+			{
+				_parent = parent;
+			}
+
+			public override void Flush()
+			{
+				_parent.Flush();
+			}
+
+			public override long Seek(long offset, SeekOrigin origin)
+			{
+				return _parent.Seek(offset, origin);
+			}
+
+			public override void SetLength(long value)
+			{
+				_parent.SetLength(value);
+			}
+
+			public override int Read(byte[] buffer, int offset, int count)
+			{
+				return _parent.Read(buffer, offset, 1);
+			}
+
+			public override void Write(byte[] buffer, int offset, int count)
+			{
+				_parent.Write(buffer, offset, count);
+			}
+
+			public override bool CanRead => _parent.CanRead;
+
+			public override bool CanSeek => _parent.CanSeek;
+
+			public override bool CanWrite => _parent.CanWrite;
+
+			public override long Length => _parent.Length;
+
+			public override long Position
+			{
+				get => _parent.Position;
+				set => _parent.Position = value;
+			}
+		}
+	}
+}

--- a/NetSerializer.UnitTests/PrimitivesTest.cs
+++ b/NetSerializer.UnitTests/PrimitivesTest.cs
@@ -11,29 +11,29 @@ namespace NetSerializer.UnitTests
 	{
 #if NET5_0
 #if NO_UNSAFE
-        [Ignore("Float and half tests are inacurrate due to rounding when NO_UNSAFE is enabled.")]
+		[Ignore("Float and half tests are inacurrate due to rounding when NO_UNSAFE is enabled.")]
 #endif
-        [Test]
-        [TestCase(0)]
-        [TestCase(1)]
-        [TestCase(123.4)]
-        [TestCase(0.01)]
-        [TestCase(double.PositiveInfinity)]
-        [TestCase(double.NegativeInfinity)]
-        [TestCase(double.NaN)]
-        public void TestHalf(double val)
-        {
-        	// Can't stick Half values in attributes so have to do this.
-        	var half = (Half) val;
+		[Test]
+		[TestCase(0)]
+		[TestCase(1)]
+		[TestCase(123.4)]
+		[TestCase(0.01)]
+		[TestCase(double.PositiveInfinity)]
+		[TestCase(double.NegativeInfinity)]
+		[TestCase(double.NaN)]
+		public void TestHalf(double val)
+		{
+			// Can't stick Half values in attributes so have to do this.
+			var half = (Half) val;
 
-        	var stream = new MemoryStream();
-        	Primitives.WritePrimitive(stream, half);
+			var stream = new MemoryStream();
+			Primitives.WritePrimitive(stream, half);
 
-        	stream.Position = 0;
+			stream.Position = 0;
 
-        	Primitives.ReadPrimitive(new ByteStream(stream), out Half read);
-        	Assert.That(read, Is.EqualTo(half));
-        }
+			Primitives.ReadPrimitive(new ByteStream(stream), out Half read);
+			Assert.That(read, Is.EqualTo(half));
+		}
 #endif
 
 #if NO_UNSAFE

--- a/NetSerializer.sln
+++ b/NetSerializer.sln
@@ -9,6 +9,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Test", "Test\Test.csproj", 
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PrimitiveTest", "PrimitiveTest\PrimitiveTest.csproj", "{CBA6D818-4B6A-4A80-95D5-7F5EC3FBB3C4}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NetSerializer.UnitTests", "NetSerializer.UnitTests\NetSerializer.UnitTests.csproj", "{17DC557B-DB9E-464C-A311-5AB83E5684AC}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -27,6 +29,10 @@ Global
 		{CBA6D818-4B6A-4A80-95D5-7F5EC3FBB3C4}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{CBA6D818-4B6A-4A80-95D5-7F5EC3FBB3C4}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{CBA6D818-4B6A-4A80-95D5-7F5EC3FBB3C4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{17DC557B-DB9E-464C-A311-5AB83E5684AC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{17DC557B-DB9E-464C-A311-5AB83E5684AC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{17DC557B-DB9E-464C-A311-5AB83E5684AC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{17DC557B-DB9E-464C-A311-5AB83E5684AC}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/NetSerializer/NetSerializer.csproj
+++ b/NetSerializer/NetSerializer.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net45;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net45;netcoreapp3.1</TargetFrameworks>
     <Description>A very fast and minimal serializer</Description>
     <Company>Tomi Valkeinen</Company>
     <Copyright>Copyright © 2012-2019 Tomi Valkeinen</Copyright>

--- a/NetSerializer/NetSerializer.csproj
+++ b/NetSerializer/NetSerializer.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net45;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net45;netcoreapp3.1;net5.0</TargetFrameworks>
     <Description>A very fast and minimal serializer</Description>
     <Company>Tomi Valkeinen</Company>
     <Copyright>Copyright © 2012-2019 Tomi Valkeinen</Copyright>

--- a/NetSerializer/Primitives.cs
+++ b/NetSerializer/Primitives.cs
@@ -12,6 +12,7 @@ using System.Reflection;
 using System.Text;
 using System.Diagnostics;
 #if NETCOREAPP
+using System.Runtime.CompilerServices;
 using System.Text.Unicode;
 using System.Buffers.Binary;
 using System.Buffers;
@@ -240,6 +241,21 @@ namespace NetSerializer
 			ulong v = ReadUInt64(stream);
 			value = *(double*)(&v);
 		}
+
+#if NET5_0
+        public static void WritePrimitive(Stream stream, Half value)
+        {
+            ushort v = Unsafe.As<Half, ushort>(ref value);
+            WriteUInt16(stream, v);
+        }
+
+        public static void ReadPrimitive(Stream stream, out Half value)
+        {
+            var v = ReadUInt16(stream);
+            value = Unsafe.As<ushort, Half>(ref v);
+        }
+#endif
+
 #else
 		public static void WritePrimitive(Stream stream, float value)
 		{
@@ -264,6 +280,21 @@ namespace NetSerializer
 			ulong v = ReadUInt64(stream);
 			value = BitConverter.Int64BitsToDouble((long)v);
 		}
+
+#if NET5_0
+		public static void WritePrimitive(Stream stream, Half value)
+		{
+			WritePrimitive(stream, (double)value);
+		}
+
+		public static void ReadPrimitive(Stream stream, out Half value)
+		{
+			double v;
+			ReadPrimitive(stream, out v);
+			value = (Half)v;
+		}
+#endif
+
 #endif
 
 		private static void WriteUInt16(Stream stream, ushort value)

--- a/NetSerializer/Primitives.cs
+++ b/NetSerializer/Primitives.cs
@@ -243,17 +243,17 @@ namespace NetSerializer
 		}
 
 #if NET5_0
-        public static void WritePrimitive(Stream stream, Half value)
-        {
-            ushort v = Unsafe.As<Half, ushort>(ref value);
-            WriteUInt16(stream, v);
-        }
+		public static void WritePrimitive(Stream stream, Half value)
+		{
+			ushort v = Unsafe.As<Half, ushort>(ref value);
+			WriteUInt16(stream, v);
+		}
 
-        public static void ReadPrimitive(Stream stream, out Half value)
-        {
-            var v = ReadUInt16(stream);
-            value = Unsafe.As<ushort, Half>(ref v);
-        }
+		public static void ReadPrimitive(Stream stream, out Half value)
+		{
+			var v = ReadUInt16(stream);
+			value = Unsafe.As<ushort, Half>(ref v);
+		}
 #endif
 
 #else
@@ -298,25 +298,25 @@ namespace NetSerializer
 #endif
 
 		private static void WriteUInt16(Stream stream, ushort value)
-	    {
-	        stream.WriteByte((byte) value);
-	        stream.WriteByte((byte) (value >> 8));
-	    }
+		{
+			stream.WriteByte((byte) value);
+			stream.WriteByte((byte) (value >> 8));
+		}
 
 		private static ushort ReadUInt16(Stream stream)
 		{
-            ushort a = 0;
+			ushort a = 0;
 
-            for (var i = 0; i < 16; i += 8)
-            {
-                var val = stream.ReadByte();
-                if (val == -1)
-                    throw new EndOfStreamException();
+			for (var i = 0; i < 16; i += 8)
+			{
+				var val = stream.ReadByte();
+				if (val == -1)
+					throw new EndOfStreamException();
 
-                a |= (ushort) (val << i);
-            }
+				a |= (ushort) (val << i);
+			}
 
-            return a;
+			return a;
 		}
 
 		// 32 and 64 bit variants use stackalloc when everything is available since it's faster.
@@ -358,21 +358,21 @@ namespace NetSerializer
 			return a;
 		}
 
-        private static ulong ReadUInt64(Stream stream)
-        {
-	        ulong a = 0;
+		private static ulong ReadUInt64(Stream stream)
+		{
+			ulong a = 0;
 
-            for (var i = 0; i < 64; i += 8)
-            {
-            	var val = stream.ReadByte();
-            	if (val < 0)
-            		throw new EndOfStreamException();
+			for (var i = 0; i < 64; i += 8)
+			{
+				var val = stream.ReadByte();
+				if (val < 0)
+					throw new EndOfStreamException();
 
-            	a |= (ulong)val << i;
-            }
+				a |= (ulong)val << i;
+			}
 
-            return a;
-        }
+			return a;
+		}
 #else
 		private static void WriteUInt32(Stream stream, uint value)
 		{

--- a/NetSerializer/Primitives.cs
+++ b/NetSerializer/Primitives.cs
@@ -13,6 +13,7 @@ using System.Text;
 using System.Diagnostics;
 #if NETCOREAPP
 using System.Text.Unicode;
+using System.Buffers.Binary;
 using System.Buffers;
 #endif
 
@@ -219,24 +220,24 @@ namespace NetSerializer
 		public static unsafe void WritePrimitive(Stream stream, float value)
 		{
 			uint v = *(uint*)(&value);
-			WriteVarint32(stream, v);
+			WriteUInt32(stream, v);
 		}
 
 		public static unsafe void ReadPrimitive(Stream stream, out float value)
 		{
-			uint v = ReadVarint32(stream);
+			uint v = ReadUInt32(stream);
 			value = *(float*)(&v);
 		}
 
 		public static unsafe void WritePrimitive(Stream stream, double value)
 		{
 			ulong v = *(ulong*)(&value);
-			WriteVarint64(stream, v);
+			WriteUInt64(stream, v);
 		}
 
 		public static unsafe void ReadPrimitive(Stream stream, out double value)
 		{
-			ulong v = ReadVarint64(stream);
+			ulong v = ReadUInt64(stream);
 			value = *(double*)(&v);
 		}
 #else
@@ -255,13 +256,143 @@ namespace NetSerializer
 		public static void WritePrimitive(Stream stream, double value)
 		{
 			ulong v = (ulong)BitConverter.DoubleToInt64Bits(value);
-			WriteVarint64(stream, v);
+			WriteUInt64(stream, v);
 		}
 
 		public static void ReadPrimitive(Stream stream, out double value)
 		{
-			ulong v = ReadVarint64(stream);
+			ulong v = ReadUInt64(stream);
 			value = BitConverter.Int64BitsToDouble((long)v);
+		}
+#endif
+
+		private static void WriteUInt16(Stream stream, ushort value)
+	    {
+	        stream.WriteByte((byte) value);
+	        stream.WriteByte((byte) (value >> 8));
+	    }
+
+		private static ushort ReadUInt16(Stream stream)
+		{
+            ushort a = 0;
+
+            for (var i = 0; i < 16; i += 8)
+            {
+                var val = stream.ReadByte();
+                if (val == -1)
+                    throw new EndOfStreamException();
+
+                a |= (ushort) (val << i);
+            }
+
+            return a;
+		}
+
+		// 32 and 64 bit variants use stackalloc when everything is available since it's faster.
+
+#if !NETCOREAPP
+		private static void WriteUInt32(Stream stream, uint value)
+		{
+			stream.WriteByte((byte) value);
+			stream.WriteByte((byte) (value >> 8));
+			stream.WriteByte((byte) (value >> 16));
+			stream.WriteByte((byte) (value >> 24));
+		}
+
+		private static void WriteUInt64(Stream stream, ulong value)
+		{
+			stream.WriteByte((byte) value);
+			stream.WriteByte((byte) (value >> 8));
+			stream.WriteByte((byte) (value >> 16));
+			stream.WriteByte((byte) (value >> 24));
+			stream.WriteByte((byte) (value >> 32));
+			stream.WriteByte((byte) (value >> 40));
+			stream.WriteByte((byte) (value >> 48));
+			stream.WriteByte((byte) (value >> 56));
+		}
+
+		private static uint ReadUInt32(Stream stream)
+		{
+			uint a = 0;
+
+			for (var i = 0; i < 32; i += 8)
+			{
+				var val = stream.ReadByte();
+				if (val < 0)
+					throw new EndOfStreamException();
+
+				a |= (uint)val << i;
+			}
+
+			return a;
+		}
+
+        private static ulong ReadUInt64(Stream stream)
+        {
+	        ulong a = 0;
+
+            for (var i = 0; i < 64; i += 8)
+            {
+            	var val = stream.ReadByte();
+            	if (val < 0)
+            		throw new EndOfStreamException();
+
+            	a |= (ulong)val << i;
+            }
+
+            return a;
+        }
+#else
+		private static void WriteUInt32(Stream stream, uint value)
+		{
+			Span<byte> buf = stackalloc byte[4];
+			BinaryPrimitives.WriteUInt32LittleEndian(buf, value);
+
+			stream.Write(buf);
+		}
+
+		private static void WriteUInt64(Stream stream, ulong value)
+		{
+			Span<byte> buf = stackalloc byte[8];
+			BinaryPrimitives.WriteUInt64LittleEndian(buf, value);
+
+			stream.Write(buf);
+		}
+
+		private static uint ReadUInt32(Stream stream)
+		{
+			Span<byte> buf = stackalloc byte[4];
+			var wSpan = buf;
+
+			while (true)
+			{
+				var read = stream.Read(wSpan);
+				if (read == 0)
+					throw new EndOfStreamException();
+				if (read == wSpan.Length)
+					break;
+				wSpan = wSpan[read..];
+			}
+
+			return BinaryPrimitives.ReadUInt32LittleEndian(buf);
+		}
+
+		private static ulong ReadUInt64(Stream stream)
+		{
+			Span<byte> buf = stackalloc byte[8];
+			var wSpan = buf;
+
+			while (true)
+			{
+				var read = stream.Read(wSpan);
+				if (read == 0)
+					throw new EndOfStreamException();
+				if (read == wSpan.Length)
+					break;
+				wSpan = wSpan[read..];
+			}
+
+			return BinaryPrimitives.ReadUInt64LittleEndian(buf);
 		}
 #endif
 

--- a/NetSerializer/TypeSerializers/PrimitivesSerializer.cs
+++ b/NetSerializer/TypeSerializers/PrimitivesSerializer.cs
@@ -1,6 +1,6 @@
 ﻿/*
  * Copyright 2015 Tomi Valkeinen
- * 
+ *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
@@ -29,6 +29,9 @@ namespace NetSerializer
 				typeof(DateTime),
 				typeof(byte[]),
 				typeof(Decimal),
+#if NET5_0
+				typeof(Half),
+#endif
 			};
 
 		public bool Handles(Type type)

--- a/PrimitiveTest/PrimitiveTest.csproj
+++ b/PrimitiveTest/PrimitiveTest.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.0;net45</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net45</TargetFrameworks>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 

--- a/PrimitiveTest/PrimitiveTest.csproj
+++ b/PrimitiveTest/PrimitiveTest.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net45</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net45;net5.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 

--- a/Test/Test.csproj
+++ b/Test/Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.0;net45</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net45</TargetFrameworks>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 

--- a/Test/Test.csproj
+++ b/Test/Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net45</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net45;net5.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 


### PR DESCRIPTION
Apologies for doing this all in one PR. Doing it separately would've produced three conflicting PRs which is even less ideal.

Optimized float serialization to be faster and write less bytes in almost all cases. Add .NET 5 `Half` support. See commits for details.

<details>
<summary>Benchmarks for writing/reading code mentioned</summary>

```
BenchmarkDotNet=v0.12.1, OS=arch 
Intel Core i7-8750H CPU 2.20GHz (Coffee Lake), 1 CPU, 12 logical and 6 physical cores
.NET Core SDK=5.0.100
  [Host]     : .NET Core 5.0.0 (CoreCLR 5.0.20.51904, CoreFX 5.0.20.51904), X64 RyuJIT
  DefaultJob : .NET Core 5.0.0 (CoreCLR 5.0.20.51904, CoreFX 5.0.20.51904), X64 RyuJIT
```

|           Method |     Mean |    Error |   StdDev |   Median |
|----------------- |---------:|---------:|---------:|---------:|
| BenchWrite16Span | 13.65 ns | 0.305 ns | 0.775 ns | 13.38 ns |                                                                                     
| BenchWrite32Span | 13.65 ns | 0.172 ns | 0.152 ns | 13.62 ns |
| BenchWrite64Span | 13.09 ns | 0.278 ns | 0.298 ns | 13.02 ns |
|  BenchRead16Span | 13.52 ns | 0.250 ns | 0.267 ns | 13.43 ns |
|  BenchRead32Span | 13.32 ns | 0.287 ns | 0.255 ns | 13.36 ns |
|  BenchRead64Span | 12.57 ns | 0.175 ns | 0.164 ns | 12.49 ns |
| BenchWrite16Byte | 10.28 ns | 0.227 ns | 0.279 ns | 10.24 ns |
| BenchWrite32Byte | 16.89 ns | 0.360 ns | 0.400 ns | 16.98 ns |
| BenchWrite64Byte | 30.58 ns | 0.639 ns | 1.261 ns | 30.42 ns |
|  BenchRead16Byte | 11.30 ns | 0.238 ns | 0.274 ns | 11.26 ns |
|  BenchRead32Byte | 16.09 ns | 0.342 ns | 0.267 ns | 16.10 ns |
|  BenchRead64Byte | 29.17 ns | 0.630 ns | 1.836 ns | 28.89 ns |

Span code is used on .NET Core/.NET 5 for 32/64 bit since it's faster.

Benchmark code:
```cs
using System;
using System.Buffers.Binary;
using System.IO;
using BenchmarkDotNet.Attributes;

namespace Content.Benchmarks
{
    [SimpleJob]
    public class NetSerializerIntBenchmark
    {
        private MemoryStream _writeStream;
        private MemoryStream _readStream;
        private ushort _x16 = 5;
        private uint _x32 = 5;
        private ulong _x64 = 5;
        private ushort _read16;
        private uint _read32;
        private ulong _read64;

        [GlobalSetup]
        public void Setup()
        {
            _writeStream = new MemoryStream(64);
            _readStream = new MemoryStream();
            _readStream.Write(new byte[]{0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8});
        }

        [Benchmark]
        public void BenchWrite16Span()
        {
            _writeStream.Position = 0;
            WriteUInt16Span(_writeStream, _x16);
        }

        [Benchmark]
        public void BenchWrite32Span()
        {
            _writeStream.Position = 0;
            WriteUInt32Span(_writeStream, _x32);
        }

        [Benchmark]
        public void BenchWrite64Span()
        {
            _writeStream.Position = 0;
            WriteUInt64Span(_writeStream, _x64);
        }

        [Benchmark]
        public void BenchRead16Span()
        {
            _readStream.Position = 0;
            _read16 = ReadUInt16Span(_readStream);
        }

        [Benchmark]
        public void BenchRead32Span()
        {
            _readStream.Position = 0;
            _read32 = ReadUInt32Span(_readStream);
        }

        [Benchmark]
        public void BenchRead64Span()
        {
            _readStream.Position = 0;
            _read64 = ReadUInt64Span(_readStream);
        }

        [Benchmark]
        public void BenchWrite16Byte()
        {
            _writeStream.Position = 0;
            WriteUInt16Byte(_writeStream, _x16);
        }

        [Benchmark]
        public void BenchWrite32Byte()
        {
            _writeStream.Position = 0;
            WriteUInt32Byte(_writeStream, _x32);
        }

        [Benchmark]
        public void BenchWrite64Byte()
        {
            _writeStream.Position = 0;
            WriteUInt64Byte(_writeStream, _x64);
        }

        [Benchmark]
        public void BenchRead16Byte()
        {
            _readStream.Position = 0;
            _read16 = ReadUInt16Byte(_readStream);
        }
        [Benchmark]
        public void BenchRead32Byte()
        {
            _readStream.Position = 0;
            _read32 = ReadUInt32Byte(_readStream);
        }

        [Benchmark]
        public void BenchRead64Byte()
        {
            _readStream.Position = 0;
            _read64 = ReadUInt64Byte(_readStream);
        }

        private static void WriteUInt16Byte(Stream stream, ushort value)
        {
            stream.WriteByte((byte) value);
            stream.WriteByte((byte) (value >> 8));
        }

        private static void WriteUInt32Byte(Stream stream, uint value)
        {
            stream.WriteByte((byte) value);
            stream.WriteByte((byte) (value >> 8));
            stream.WriteByte((byte) (value >> 16));
            stream.WriteByte((byte) (value >> 24));
        }

        private static void WriteUInt64Byte(Stream stream, ulong value)
        {
            stream.WriteByte((byte) value);
            stream.WriteByte((byte) (value >> 8));
            stream.WriteByte((byte) (value >> 16));
            stream.WriteByte((byte) (value >> 24));
            stream.WriteByte((byte) (value >> 32));
            stream.WriteByte((byte) (value >> 40));
            stream.WriteByte((byte) (value >> 48));
            stream.WriteByte((byte) (value >> 56));
        }

        private static ushort ReadUInt16Byte(Stream stream)
        {
            ushort a = 0;

            for (var i = 0; i < 16; i += 8)
            {
                var val = stream.ReadByte();
                if (val == -1)
                    throw new EndOfStreamException();

                a |= (ushort) (val << i);
            }

            return a;
        }

        private static uint ReadUInt32Byte(Stream stream)
        {
            uint a = 0;

            for (var i = 0; i < 32; i += 8)
            {
                var val = stream.ReadByte();
                if (val == -1)
                    throw new EndOfStreamException();

                a |= (uint) (val << i);
            }

            return a;
        }

        private static ulong ReadUInt64Byte(Stream stream)
        {
            ulong a = 0;

            for (var i = 0; i < 64; i += 8)
            {
                var val = stream.ReadByte();
                if (val == -1)
                    throw new EndOfStreamException();

                a |= (ulong) (val << i);
            }

            return a;
        }

        private static void WriteUInt16Span(Stream stream, ushort value)
        {
            Span<byte> buf = stackalloc byte[2];
            BinaryPrimitives.WriteUInt16LittleEndian(buf, value);

            stream.Write(buf);
        }

        private static void WriteUInt32Span(Stream stream, uint value)
        {
            Span<byte> buf = stackalloc byte[4];
            BinaryPrimitives.WriteUInt32LittleEndian(buf, value);

            stream.Write(buf);
        }

        private static void WriteUInt64Span(Stream stream, ulong value)
        {
            Span<byte> buf = stackalloc byte[8];
            BinaryPrimitives.WriteUInt64LittleEndian(buf, value);

            stream.Write(buf);
        }

        private static ushort ReadUInt16Span(Stream stream)
        {
            Span<byte> buf = stackalloc byte[2];
            var wSpan = buf;

            while (true)
            {
                var read = stream.Read(wSpan);
                if (read == 0)
                    throw new EndOfStreamException();
                if (read == wSpan.Length)
                    break;
                wSpan = wSpan[read..];
            }

            return BinaryPrimitives.ReadUInt16LittleEndian(buf);
        }

        private static uint ReadUInt32Span(Stream stream)
        {
            Span<byte> buf = stackalloc byte[4];
            var wSpan = buf;

            while (true)
            {
                var read = stream.Read(wSpan);
                if (read == 0)
                    throw new EndOfStreamException();
                if (read == wSpan.Length)
                    break;
                wSpan = wSpan[read..];
            }

            return BinaryPrimitives.ReadUInt32LittleEndian(buf);
        }

        private static ulong ReadUInt64Span(Stream stream)
        {
            Span<byte> buf = stackalloc byte[8];
            var wSpan = buf;

            while (true)
            {
                var read = stream.Read(wSpan);
                if (read == 0)
                    throw new EndOfStreamException();
                if (read == wSpan.Length)
                    break;
                wSpan = wSpan[read..];
            }

            return BinaryPrimitives.ReadUInt64LittleEndian(buf);
        }
    }
}
```

</details>

<details>

<summary>Proof that compressed int writing for floats does not help</summary>

```cs
[Test]
public void TestAllHalf()
{
	ushort i = 0;
	var ms = new MemoryStream();
	do
	{
		var half = Unsafe.As<ushort, Half>(ref i);

		if (Half.IsNormal(half) || Half.IsInfinity(half) || Half.IsNaN(half))
		{
			Primitives.WritePrimitive(ms, half);
			Assert.That(ms.Position != 1, $"Failed: {i}");
			ms.Position = 0;
		}

		i += 1;
	} while (i != ushort.MaxValue);
}

[Test]
public void TestAllFloat()
{
	Assert.Multiple(() =>
	{
		uint i = 0;
		var ms = new MemoryStream();
		do
		{
			var single = Unsafe.As<uint, float>(ref i);

			if (float.IsNormal(single) || float.IsInfinity(single) || float.IsNaN(single))
			{
				Primitives.WritePrimitive(ms, single);
				if (ms.Position < 3)
				{
					Assert.Fail($"Failed: {i}");
				}
				ms.Position = 0;
			}

			i += 1;
		} while (i != uint.MaxValue);
	});
}
```cs

</details>